### PR TITLE
Removed mystery line.

### DIFF
--- a/src/app/canvas/canvas.directive.ts
+++ b/src/app/canvas/canvas.directive.ts
@@ -75,7 +75,6 @@ export class CanvasDirective implements OnInit, OnChanges {
 
   private render() {
     this.drawPoints(this.getExpandedPoints);
-    this.drawLine(this.getExpandedPoints);
     if (this.param.showGrid) {
       this.renderGrid(this.getExpandedPoints);
     }


### PR DESCRIPTION
Removed call of `drawLine()` from the `render()` method.  It seems that call was superfluous, as it is also called in `spreadLines()`.  